### PR TITLE
feat：未登録の予約番号読み込み時に、404エラーを返すように例外処理を実装。

### DIFF
--- a/src/main/java/org/example/catcafereservation/CustomExceptionHandler.java
+++ b/src/main/java/org/example/catcafereservation/CustomExceptionHandler.java
@@ -1,0 +1,27 @@
+package org.example.catcafereservation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(value = ReservationNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleReservationNotFoundException(
+            ReservationNotFoundException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", ZonedDateTime.now().toString());
+        body.put("status", HttpStatus.NOT_FOUND.value());
+        body.put("error", HttpStatus.NOT_FOUND.getReasonPhrase());
+        body.put("message", ex.getMessage());
+        body.put("next_steps", "予約番号が正しいことを確認してください。問題が解決しない場合は、カスタマーサポートまでお問い合わせください。");
+
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/org/example/catcafereservation/ReservationController.java
+++ b/src/main/java/org/example/catcafereservation/ReservationController.java
@@ -18,8 +18,7 @@ public class ReservationController {
 
     @GetMapping("/{reservationNumber}")
     public ResponseEntity<Reservation> getReservation(@PathVariable String reservationNumber) {
-        return reservationService.findByReservationNumber(reservationNumber)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        Reservation reservation = reservationService.findByReservationNumber(reservationNumber);
+        return ResponseEntity.ok(reservation);
     }
 }

--- a/src/main/java/org/example/catcafereservation/ReservationNotFoundException.java
+++ b/src/main/java/org/example/catcafereservation/ReservationNotFoundException.java
@@ -1,0 +1,8 @@
+package org.example.catcafereservation;
+
+public class ReservationNotFoundException extends RuntimeException {
+
+    public ReservationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/example/catcafereservation/ReservationService.java
+++ b/src/main/java/org/example/catcafereservation/ReservationService.java
@@ -2,8 +2,6 @@ package org.example.catcafereservation;
 
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 public class ReservationService {
 
@@ -13,7 +11,8 @@ public class ReservationService {
         this.reservationMapper = reservationMapper;
     }
 
-    public Optional<Reservation> findByReservationNumber(String reservationNumber) {
-        return reservationMapper.findByReservationNumber(reservationNumber);
+    public Reservation findByReservationNumber(String reservationNumber) {
+        return reservationMapper.findByReservationNumber(reservationNumber)
+                .orElseThrow(() -> new ReservationNotFoundException("お探しの予約情報は存在しません。"));
     }
 }

--- a/src/main/java/org/example/catcafereservation/ReservationService.java
+++ b/src/main/java/org/example/catcafereservation/ReservationService.java
@@ -13,7 +13,8 @@ public class ReservationService {
         this.reservationMapper = reservationMapper;
     }
 
-    public Optional<Reservation> findByReservationNumber(String reservationNumber) {
-        return reservationMapper.findByReservationNumber(reservationNumber);
+    public Reservation findByReservationNumber(String reservationNumber) {
+        return reservationMapper.findByReservationNumber(reservationNumber)
+                .orElseThrow(() -> new ReservationNotFoundException("お探しの予約情報は存在しません。正しい予約番号をご確認ください。"));
     }
 }


### PR DESCRIPTION
# 概要
未登録の予約番号でリクエストされた際、404エラー及びエラーメッセージを返すように例外処理を実装しました。
コミットハッシュ： 964ed83de8910d4f745395cac600ec0311c54361

エラーメッセージが一部被っていたので、削除しました。
また、使用していないimport文を削除しました。
コミットハッシュ： 1f97066a333d9d1bfb46aa72c64c3617bdf0ab85 

## Postmanによる動作確認結果
存在しない予約番号のレコードをリクエストし、下記のとおり狙ったレスポンスが返ってきました。
- 404エラーになっている 。（画像1・2）
- CustomExceptionHandlerクラス記載のとおりの情報＆ReservationServiceクラス記載の文言が表示されている 。（画像1）
- Content-Type が「json」である。（画像2）
</br>

![image](https://github.com/Ema-Sakai/Assignment-10/assets/166620990/ecb2e2c0-48a8-44de-a24c-b1e7ffe496f2)
</br>

![image](https://github.com/Ema-Sakai/Assignment-10/assets/166620990/35eff7e9-1173-4131-b2d7-e6eb5ae3bf09)
