### PR TITLE
feat：POST及びGETに対してバリデーションを実装。

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.34'
     annotationProcessor 'org.projectlombok:lombok:1.18.34'
     implementation 'de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/catcafereservation/ReservationController.java
+++ b/src/main/java/org/example/catcafereservation/ReservationController.java
@@ -1,6 +1,7 @@
 package org.example.catcafereservation;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -19,7 +20,7 @@ public class ReservationController {
     private final ReservationService reservationService;
 
     @GetMapping("/{reservationNumber}")
-    public ResponseEntity<Reservation> getReservation(@PathVariable String reservationNumber) {
+    public ResponseEntity<Reservation> getReservation(@PathVariable @ValidReservationNumber @NotBlank String reservationNumber) {
         Reservation reservation = reservationService.findByReservationNumber(reservationNumber);
         return ResponseEntity.ok(reservation);
     }

--- a/src/main/java/org/example/catcafereservation/ReservationController.java
+++ b/src/main/java/org/example/catcafereservation/ReservationController.java
@@ -1,7 +1,9 @@
 package org.example.catcafereservation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -11,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 @RestController
 @RequestMapping("/reservations")
 @RequiredArgsConstructor
+@Validated(ValidationOrder.class)
 public class ReservationController {
 
     private final ReservationService reservationService;
@@ -22,7 +25,7 @@ public class ReservationController {
     }
 
     @PostMapping("/")
-    public ResponseEntity<ReservationResponse> insert(@RequestBody ReservationRequest reservationRequest, UriComponentsBuilder uriBuilder) {
+    public ResponseEntity<ReservationResponse> insert(@Valid @RequestBody ReservationRequest reservationRequest, UriComponentsBuilder uriBuilder) {
         Reservation reservation = reservationService.insert(reservationRequest.convertToEntity());
 
         String reservationNumber = reservation.getReservationNumber();

--- a/src/main/java/org/example/catcafereservation/ReservationNumberValidator.java
+++ b/src/main/java/org/example/catcafereservation/ReservationNumberValidator.java
@@ -1,0 +1,14 @@
+package org.example.catcafereservation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ReservationNumberValidator implements ConstraintValidator<ValidReservationNumber, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+        return value.length() == 26;
+    }
+}

--- a/src/main/java/org/example/catcafereservation/ReservationRequest.java
+++ b/src/main/java/org/example/catcafereservation/ReservationRequest.java
@@ -1,5 +1,6 @@
 package org.example.catcafereservation;
 
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +13,25 @@ import java.time.LocalTime;
 @AllArgsConstructor
 public class ReservationRequest {
 
+    @NotBlank(message = "予約名の入力は必須です。", groups = ValidationGroups.NotBlankGroup.class)
+    @Size(max = 50, message = "予約名は50文字以内で入力してください。", groups = ValidationGroups.PatternGroup.class)
     private String name;
+
+    //予約日時はフロント側で入力規則（画面上での選択方法）をコントロールできるためNotNullを採用。
+    @NotNull(message = "ご希望の予約日選択は必須です。", groups = ValidationGroups.NotBlankGroup.class)
+    @FutureOrPresent(message = "明日以降のご希望日を選択してください。", groups = ValidationGroups.PatternGroup.class)
     private LocalDate reservationDate;
+
+    @NotNull(message = "ご希望の予約時間選択は必須です。", groups = ValidationGroups.NotBlankGroup.class)
+    @ValidReservationTime(groups = ValidationGroups.PatternGroup.class)
     private LocalTime reservationTime;
+
+    @NotBlank(message = "メールアドレスの入力は必須です。", groups = ValidationGroups.NotBlankGroup.class)
+    @Email(message = "有効なメールアドレスを入力してください。", groups = ValidationGroups.PatternGroup.class)
     private String email;
+
+    @NotBlank(message = "電話番号の入力は必須です。", groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[0-9]{11}$", message = "電話番号を数字のみ11桁で入力してください。（例：09012345678）", groups = ValidationGroups.PatternGroup.class)
     private String phone;
 
     public Reservation convertToEntity() {

--- a/src/main/java/org/example/catcafereservation/ReservationTimeValidator.java
+++ b/src/main/java/org/example/catcafereservation/ReservationTimeValidator.java
@@ -1,0 +1,19 @@
+package org.example.catcafereservation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalTime;
+
+public class ReservationTimeValidator implements ConstraintValidator<ValidReservationTime, LocalTime> {
+    @Override
+    public boolean isValid(LocalTime value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        int hour = value.getHour();
+        int minute = value.getMinute();
+        return (hour >= 11 && hour <= 14) && (minute == 0 || minute == 30);
+    }
+
+}

--- a/src/main/java/org/example/catcafereservation/ValidReservationNumber.java
+++ b/src/main/java/org/example/catcafereservation/ValidReservationNumber.java
@@ -1,0 +1,20 @@
+package org.example.catcafereservation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = ReservationNumberValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidReservationNumber {
+    String message() default "26桁の予約番号を入力してください。";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/example/catcafereservation/ValidReservationTime.java
+++ b/src/main/java/org/example/catcafereservation/ValidReservationTime.java
@@ -1,0 +1,20 @@
+package org.example.catcafereservation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = ReservationTimeValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidReservationTime {
+    String message() default "予約時間は11:00から14:00までの間で、30分単位で選択してください。（例: 11:00、11:30）";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/example/catcafereservation/ValidationGroups.java
+++ b/src/main/java/org/example/catcafereservation/ValidationGroups.java
@@ -1,0 +1,9 @@
+package org.example.catcafereservation;
+
+public interface ValidationGroups {
+    interface NotBlankGroup {
+    }
+
+    interface PatternGroup {
+    }
+}

--- a/src/main/java/org/example/catcafereservation/ValidationOrder.java
+++ b/src/main/java/org/example/catcafereservation/ValidationOrder.java
@@ -1,0 +1,8 @@
+package org.example.catcafereservation;
+
+import jakarta.validation.GroupSequence;
+import jakarta.validation.groups.Default;
+
+@GroupSequence({ValidationGroups.NotBlankGroup.class, ValidationGroups.PatternGroup.class, Default.class})
+public interface ValidationOrder {
+}


### PR DESCRIPTION
# 概要
Create処理に対してバリデーションを実装しました。
コミットハッシュ： fbfec743ffea7cd074aa510aa3f0327b349e72af （バリデーションの追加。）
コミットハッシュ： 054467104f507039671dcac2dd0204e184b71d53 （グループシーケンスの実装。）
コミットハッシュ： 1840defd0d251937e58b61aafb3594c286de2fc8 （例外ハンドラーの編集。）

また、Read処理に対しても追加でバリデーションを実装しました。
コミットハッシュ： b7831a952f16f9239d99240af39499d81f5daab2

## Create処理に対してのバリデーション動作確認（Postmanにて）
下記2つの状態において正常に動作するか確認しました。
1. 項目が空だった場合。
2.  入力されているが、ルールに満たない場合。（ただし予約希望日時は、フロント側でプルダウン式など入力方法をコントロールすると仮定しています。）

※正常とは
- ステータスが400エラーを返す。
- リクエストボディが状況に則したエラーメッセージを返す。

</br>

### 動作確認結果画像

1. 全ての項目が空だった場合。

ステータスが400、且つ`@NotBlank`もしくは`@NotNull`に対応したエラーメッセージがボディに表示される。

![image](https://github.com/user-attachments/assets/6307c4bf-3e80-4b96-b5d6-211c71123dec)

</br>
 2. 入力されているが、ルールに満たない場合。

入力規則をユーザー側へ返す。


![image](https://github.com/user-attachments/assets/ba029916-dc6d-4cde-ba03-a08a480872f3)


## Read処理に対してのバリデーション動作確認（Postmanにて）
下記2つの状態において動作するか確認しました。
1. 入力値が不正だった場合は、バリデーション結果（BAD_REQUEST：400エラー）を返す。
2. 入力値が見つからなかった場合は、Read処理実装時に対応した例外処理（NOT_FOUND：404エラー）を返す。

</br>

### 動作確認結果画像

1. 以下のとおり、入力値が不正な場合はバリデーションが働く。

![image](https://github.com/user-attachments/assets/d8a545b7-81d0-453c-9abd-ca7147223dfc)

</br>
 2. 改めての確認だが、DBに予約番号がないと404エラーを返す。
 
![image](https://github.com/user-attachments/assets/cf7cb0c2-f420-42f6-a371-f1d0076b0260)
