### PR TITLE
feat：Delete処理機能を実装。

### DIFF
--- a/src/main/java/org/example/catcafereservation/ReservationController.java
+++ b/src/main/java/org/example/catcafereservation/ReservationController.java
@@ -10,6 +10,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/reservations")
@@ -63,6 +65,14 @@ public class ReservationController {
                 updatedReservation.getReservationNumber()
         );
 
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{reservationNumber}")
+    public ResponseEntity<Map<String, String>> deleteReservation(@PathVariable @ValidReservationNumber String reservationNumber) {
+        reservationService.deleteReservation(reservationNumber);
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "予約情報を削除いたしました。");
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/example/catcafereservation/ReservationMapper.java
+++ b/src/main/java/org/example/catcafereservation/ReservationMapper.java
@@ -21,4 +21,10 @@ public interface ReservationMapper {
 
     @Update("UPDATE reservations SET reservation_date = #{reservationDate}, reservation_time = #{reservationTime} WHERE id = #{id}")
     void update(Reservation reservation);
+
+    @Delete("DELETE FROM reservations_numbers WHERE reservation_number = #{reservationNumber}")
+    void deleteReservationNumber(String reservationNumber);
+
+    @Delete("DELETE FROM reservations WHERE id = #{id}")
+    void deleteReservation(Integer id);
 }

--- a/src/main/java/org/example/catcafereservation/ReservationService.java
+++ b/src/main/java/org/example/catcafereservation/ReservationService.java
@@ -56,4 +56,13 @@ public class ReservationService {
         reservationMapper.update(reservation);
         return reservation;
     }
+
+    @Transactional
+    public void deleteReservation(String reservationNumber) {
+        Reservation reservation = reservationMapper.findByReservationNumber(reservationNumber)
+                .orElseThrow(() -> new ReservationNotFoundException("該当する予約番号は存在しません。"));
+
+        reservationMapper.deleteReservationNumber(reservationNumber);
+        reservationMapper.deleteReservation(reservation.getId());
+    }
 }


### PR DESCRIPTION
# 概要
予約番号を使用し、予約情報を削除するDelete機能を実装しました。
また、今回は削除が完了した旨をレスポンスしたいため、ステータスは204ではなく200になるように実装しました。

 [feat:Delete機能の実装。](https://github.com/Ema-Sakai/Assignment-10/pull/7/commits/03ea2640f1924dc0d1a1b05739ffa3bda5f8c4ba)

</br>

## Postmanでの動作確認結果
今回は添付画像の予約情報に対して、下記4パターンの挙動がどうなるか確認しました。
動作確認の結果、問題なしと判断いたしました。
判断に至った根拠は、後述しています各結果の確認をお願いいたします。

![image](https://github.com/user-attachments/assets/bdf62149-1d17-49a9-8df4-3e52f698a377)

1. 予約番号が桁数過不足による不正なリクエストの場合。
2. 予約番号が未登録なリクエストの場合。
3. 予約番号がDBに登録されているリクエストの場合。
4. 削除済みの予約番号にさらにリクエストした場合。


### 1.不正なリクエストの場合
- ステータスが400エラー。
- 対応するエラーメッセージが表示される。

![image](https://github.com/user-attachments/assets/bf18fe35-c666-420c-ba57-090ebe351fef)

</br>

### 2.予約番号が未登録の場合
- ステータスが404エラー。
- 対応するエラーメッセージが表示される。

![image](https://github.com/user-attachments/assets/07757368-e5a4-4155-a02a-eb9218c133d3)

</br>

### 3.正常な内容をリクエストした場合
- ステータスが200。
- 対応するメッセージが表示される。（添付画像1）
- DBの`reservations`テーブルと`reservations_numbers`テーブルから、該当データが削除されたことを確認。

![image](https://github.com/user-attachments/assets/db95af9a-5163-4f33-82c3-b55f00d8f700)
![image](https://github.com/user-attachments/assets/9dbeacbf-135f-44b3-9c9a-7edce637d85e)

</br>

### 4.削除済みの予約番号をリクエストした場合。
- ステータスが404エラー。
- 対応するエラーメッセージが表示される。

![image](https://github.com/user-attachments/assets/aa397d41-8b02-43ca-a0ed-2a881a12bc7f)
