### PR TITLE
feat：Read機能に対する単体テストと、それを実行するワークフローを実装。

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,31 @@
+name: Run Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        
+    - name: Setup DB
+      run: docker compose up -d
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+
+    - name: Test with Gradle Wrapper
+      run: ./gradlew test

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -14,18 +14,21 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        
-    - name: Setup DB
-      run: docker compose up -d
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+      - name: Setup DB
+        run: docker compose up -d
 
-    - name: Test with Gradle Wrapper
-      run: ./gradlew test
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Test with Gradle Wrapper
+        run: ./gradlew test

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.34'
     implementation 'de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.1'
+    implementation 'com.github.database-rider:rider-spring:1.44.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/org/example/catcafereservation/ReservationServiceTest.java
+++ b/src/test/java/org/example/catcafereservation/ReservationServiceTest.java
@@ -1,0 +1,56 @@
+package org.example.catcafereservation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ReservationServiceTest {
+
+    @Mock
+    private ReservationMapper reservationMapper;
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    @Test
+    public void 存在する予約番号を指定したときに正常に予約情報が返されること() {
+        String reservationNumber = "validReservationNumber123";
+        Reservation expectedReservation = new Reservation(1, "Test User", LocalDate.of(2024, 8, 7), LocalTime.of(12, 0), "test@example.com", "09012345678", reservationNumber);
+        doReturn(Optional.of(expectedReservation)).when(reservationMapper).findByReservationNumber(reservationNumber);
+
+        Reservation actualReservation = reservationService.findByReservationNumber(reservationNumber);
+
+        assertThat(actualReservation).isEqualTo(expectedReservation);
+        verify(reservationMapper, times(1)).findByReservationNumber(reservationNumber);
+    }
+
+    @Test
+    public void 存在しない予約番号を指定したときにエラーが返されること() {
+        String reservationNumber = "invalidReservationNumber123";
+        doReturn(Optional.empty()).when(reservationMapper).findByReservationNumber(reservationNumber);
+
+        assertThrows(ReservationNotFoundException.class, () -> reservationService.findByReservationNumber(reservationNumber));
+        verify(reservationMapper, times(1)).findByReservationNumber(reservationNumber);
+    }
+
+    @Test
+    public void 予約番号がNullのときにエラーが返されること() {
+        assertThrows(ReservationNotFoundException.class, () -> reservationService.findByReservationNumber(null));
+    }
+
+    @Test
+    public void 予約番号が空文字のときにエラーが返されること() {
+        assertThrows(ReservationNotFoundException.class, () -> reservationService.findByReservationNumber(""));
+    }
+}


### PR DESCRIPTION
# 概要
Read機能に対する単体テストを実装しました。
また、自動で実行できるようにGitHub Actions関連の設定も行いました。

- feat：Read機能に対する単体テストと、それを実行するワークフローを実装：[db9ba5d](https://github.com/Ema-Sakai/Assignment-10/pull/8/commits/db9ba5d8bf16b97e36c025ac78fac22893f11490)

- feat:あとで必要になるDatabase Riderを依存関係に追加：[27e8065](https://github.com/Ema-Sakai/Assignment-10/pull/8/commits/27e80650cf10b0e247c5cfec9bf600172a397494)

- feat:Read機能に対する単体テストを実装：[eb3902c](https://github.com/Ema-Sakai/Assignment-10/pull/8/commits/eb3902c1d89e7bf240996abd4d8c64426af11b82)

- change:gradlew ファイルに実行権限を付与：[a6842e7](https://github.com/Ema-Sakai/Assignment-10/pull/8/commits/a6842e7d016ef803828f9df6040b5849abf6c6a0)


# 自動実行の結果
画像のとおりテストをパスしています。
![image](https://github.com/user-attachments/assets/33d0a2dc-8de6-4bf2-a327-f8d029d7ae01)
