### PR TITLE
feat：EqualsAndHashCodeアノテーションの追加と、関連するDBテストを一部修正。

### DIFF
--- a/src/main/java/org/example/catcafereservation/Reservation.java
+++ b/src/main/java/org/example/catcafereservation/Reservation.java
@@ -1,6 +1,10 @@
 package org.example.catcafereservation;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/main/java/org/example/catcafereservation/Reservation.java
+++ b/src/main/java/org/example/catcafereservation/Reservation.java
@@ -1,9 +1,6 @@
 package org.example.catcafereservation;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -12,6 +9,7 @@ import java.time.LocalTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class Reservation {
 
     private Integer id;

--- a/src/test/java/org/example/catcafereservation/ReservationMapperTest.java
+++ b/src/test/java/org/example/catcafereservation/ReservationMapperTest.java
@@ -33,20 +33,13 @@ class ReservationMapperTest {
         void 指定した予約番号の予約情報を取得できること() {
             // Arrange
             String reservationNumber = "01J2K2JKM8Y8QES70ZQ0S73JSR";
+            Reservation expected = new Reservation(1, "名前はにゃんでも登録できちゃうにゃん太郎", LocalDate.of(2024, 9, 20), LocalTime.of(11, 30), "test@example.com", "02022222222", reservationNumber);
 
             // Act
             Optional<Reservation> actual = reservationMapper.findByReservationNumber(reservationNumber);
 
             // Assert
-            assertThat(actual).hasValueSatisfying(reservation -> {
-                assertThat(reservation.getId()).isEqualTo(1);
-                assertThat(reservation.getName()).isEqualTo("名前はにゃんでも登録できちゃうにゃん太郎");
-                assertThat(reservation.getReservationDate()).isEqualTo(LocalDate.of(2024, 9, 20));
-                assertThat(reservation.getReservationTime()).isEqualTo(LocalTime.of(11, 30));
-                assertThat(reservation.getEmail()).isEqualTo("test@example.com");
-                assertThat(reservation.getPhone()).isEqualTo("02022222222");
-                assertThat(reservation.getReservationNumber()).isEqualTo(reservationNumber);
-            });
+            assertThat(actual).hasValue(expected);
         }
 
         @Test
@@ -73,19 +66,18 @@ class ReservationMapperTest {
         @Transactional
         void 予約情報が登録できること() {
             // Arrange
-            Reservation newReservation = new Reservation("新しい予約のにゃん太郎", LocalDate.of(2024, 10, 10), LocalTime.of(12, 0), "new@example.com", "09012345678");
-            String reservationNumber = "03J2K1JKM8Y8QES70ZQ0S73JSR";
+            Reservation newReservation = new Reservation(null, "新しい予約のにゃん太郎", LocalDate.of(2024, 10, 10), LocalTime.of(12, 0), "new@example.com", "09012345678", "03J2K1JKM8Y8QES70ZQ0S73JSR");
 
             // Act
             reservationMapper.insert(newReservation);
-            reservationMapper.insertReservationNumber(reservationNumber, newReservation.getId());
+            reservationMapper.insertReservationNumber(newReservation.getReservationNumber(), newReservation.getId());
 
             // Assert
-            assertThat(newReservation.getId()).isNotNull().isGreaterThan(0);
-            assertThat(reservationNumber).isNotNull().hasSize(26);
+            Optional<Reservation> actual = reservationMapper.findByReservationNumber(newReservation.getReservationNumber());
+            assertThat(actual).hasValue(newReservation);
 
             // Check for uniqueness
-            Optional<Reservation> duplicateReservation = reservationMapper.findByReservationNumber(reservationNumber);
+            Optional<Reservation> duplicateReservation = reservationMapper.findByReservationNumber(newReservation.getReservationNumber());
             assertThat(duplicateReservation).isPresent();
             assertThat(duplicateReservation.get().getId()).isEqualTo(newReservation.getId());
         }
@@ -107,10 +99,7 @@ class ReservationMapperTest {
 
             // Assert
             Optional<Reservation> actual = reservationMapper.findByReservationNumber("01J2K2JKM8Y8QES70ZQ0S73JSR");
-            assertThat(actual).hasValueSatisfying(reservation -> {
-                assertThat(reservation.getId()).isEqualTo(1);
-                assertThat(reservation.getReservationNumber()).isEqualTo("01J2K2JKM8Y8QES70ZQ0S73JSR");
-            });
+            assertThat(actual).hasValue(updatedReservation);
         }
     }
 


### PR DESCRIPTION
# 概要
DBテストのPRでレビューいただいた際に、`equals`と`hashCode`を利用した検証を提案いただいたため、Reservationクラスにアノテーションを追加し、DBテストコードを一部修正いたしました。
- [feat:ReservationクラスにequalsとhashCodeメソッドを実装するための、アノテーションを追加。](https://github.com/Ema-Sakai/Assignment-10/pull/13/commits/5deda8aee7281c0eed2239503286ff9c895883b6)
- [change:equalsとhashCodeメソッドを利用して、テストの検証コードを修正。](https://github.com/Ema-Sakai/Assignment-10/pull/13/commits/b6d3e91f8f7d6ebe51ad829d109485b0ce6b3322)


テストは画像のとおり、パスしています。
![image](https://github.com/user-attachments/assets/9101e9ac-83b8-4b45-8a87-c08d33cf941c)
