### PR TITLE
feat：CRUD機能への結合テスト実装。

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -54,3 +54,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew build sonar --info
+
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test

--- a/src/test/java/org/example/catcafereservation/integrationtest/ReservationApiIntegrationTest.java
+++ b/src/test/java/org/example/catcafereservation/integrationtest/ReservationApiIntegrationTest.java
@@ -1,0 +1,147 @@
+package org.example.catcafereservation.integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class ReservationApiIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Nested
+    class CreateTests {
+
+        @Test
+        @DataSet(value = "datasets/reservations.yml")
+        @ExpectedDataSet(value = "datasets/expected_reservations_after_create.yml", ignoreCols = {"id", "reservation_id", "reservation_number"})
+        @Transactional
+        void 新しい予約情報を作成できて予約情報がレスポンスされること() throws Exception {
+            // Arrange
+            String newReservationJson = """
+                    {
+                        "name": "新しい予約のにゃん太郎",
+                        "reservationDate": "2024-10-10",
+                        "reservationTime": "12:00",
+                        "email": "new@example.com",
+                        "phone": "09012345678"
+                    }
+                    """;
+
+            // Act & Assert
+            mockMvc.perform(post("/reservations/")
+                            .contentType("application/json")
+                            .content(newReservationJson))
+                    .andExpectAll(
+                            status().isCreated(),
+                            header().exists("Location"),
+                            content().json("""
+                                    {
+                                        "message": "以下の通り予約が完了しました。",
+                                        "reservationDate": "2024年10月10日",
+                                        "reservationTime": "12時00分",
+                                        "name": "新しい予約のにゃん太郎",
+                                        "email": "new@example.com",
+                                        "phone": "09012345678"
+                                    }
+                                    """)
+                    )
+                    .andExpect(result -> {
+                        String content = result.getResponse().getContentAsString();
+                        JSONObject jsonObject = new JSONObject(content);
+                        String reservationNumber = jsonObject.getString("reservationNumber");
+
+                        assertAll(
+                                () -> assertThat(reservationNumber).isNotNull(),
+                                () -> assertThat(reservationNumber).hasSize(26),
+                                () -> assertThat(reservationNumber).matches("[A-Z0-9]{26}")
+                        );
+                    });
+        }
+
+        @Test
+        @Transactional
+        void バリデーションに引っかかる内容でリクエストするとBadRequestと入力規則が返ること() throws Exception {
+            // Arrange
+            String invalidReservationJson = """
+                    {
+                        "name": "00000000000000000000000000000000000000000_50文字以上の名前",
+                        "reservationDate": "2024-09-09",
+                        "reservationTime": "10:00",
+                        "email": "invalid-email",
+                        "phone": "123"
+                    }
+                    """;
+
+            // Act & Assert
+            mockMvc.perform(MockMvcRequestBuilders.post("/reservations/")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(invalidReservationJson))
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            jsonPath("$.message").value("入力内容に誤りがあります。"),
+                            jsonPath("$.errors['insert.reservationRequest.name']").value("予約名は50文字以内で入力してください。"),
+                            jsonPath("$.errors['insert.reservationRequest.reservationDate']").value("明日以降のご希望日を選択してください。"),
+                            jsonPath("$.errors['insert.reservationRequest.reservationTime']").value("予約時間は11:00から14:00までの間で、30分単位で選択してください。（例: 11:00、11:30）"),
+                            jsonPath("$.errors['insert.reservationRequest.email']").value("有効なメールアドレスを入力してください。"),
+                            jsonPath("$.errors['insert.reservationRequest.phone']").value("電話番号を数字のみ11桁で入力してください。（例：09012345678）")
+                    );
+        }
+
+        @Test
+        @Transactional
+        void 空文字でリクエストするとBadRequestとエラーメッセージが返ること() throws Exception {
+            // Arrange
+            String invalidReservationJson = """
+                    {
+                        "name": "",
+                        "reservationDate": "",
+                        "reservationTime": "",
+                        "email": "",
+                        "phone": ""
+                    }
+                    """;
+
+            // Act & Assert
+            mockMvc.perform(MockMvcRequestBuilders.post("/reservations/")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(invalidReservationJson))
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            jsonPath("$.message").value("入力内容に誤りがあります。"),
+                            jsonPath("$.errors['insert.reservationRequest.name']").value("予約名の入力は必須です。"),
+                            jsonPath("$.errors['insert.reservationRequest.reservationDate']").value("ご希望の予約日選択は必須です。"),
+                            jsonPath("$.errors['insert.reservationRequest.reservationTime']").value("ご希望の予約時間を選択してください。"),
+                            jsonPath("$.errors['insert.reservationRequest.email']").value("メールアドレスの入力は必須です。"),
+                            jsonPath("$.errors['insert.reservationRequest.phone']").value("電話番号の入力は必須です。")
+                    );
+        }
+    }
+}

--- a/src/test/java/org/example/catcafereservation/integrationtest/ReservationApiIntegrationTest.java
+++ b/src/test/java/org/example/catcafereservation/integrationtest/ReservationApiIntegrationTest.java
@@ -272,6 +272,7 @@ public class ReservationApiIntegrationTest {
 
         @ParameterizedTest
         @Transactional
+        @DataSet(value = "datasets/reservations.yml")
         @CsvSource({
                 "'2024-10-10', '10:00:00', 2, '時間が受付外'",
                 "'2024-09-09', '12:00:00', 2, '日付が受付外'",

--- a/src/test/java/org/example/catcafereservation/integrationtest/ReservationApiIntegrationTest.java
+++ b/src/test/java/org/example/catcafereservation/integrationtest/ReservationApiIntegrationTest.java
@@ -56,7 +56,7 @@ public class ReservationApiIntegrationTest {
                     """;
 
             // Act & Assert
-            mockMvc.perform(post("/reservations/")
+            mockMvc.perform(MockMvcRequestBuilders.post("/reservations/")
                             .contentType("application/json")
                             .content(newReservationJson))
                     .andExpectAll(
@@ -156,7 +156,7 @@ public class ReservationApiIntegrationTest {
             String reservationNumber = "01J2K2JKM8Y8QES70ZQ0S73JSR";
 
             // Act & Assert
-            mockMvc.perform(get("/reservations/" + reservationNumber))
+            mockMvc.perform(MockMvcRequestBuilders.get("/reservations/" + reservationNumber))
                     .andExpectAll(
                             status().isOk(),
                             content().json("""


### PR DESCRIPTION
# 概要
CRUD機能に対して結合テストを実施しました。
テスト結果は[こちらのページ下部のtest-report](https://github.com/Ema-Sakai/Assignment-10/actions/runs/10880505796) よりDL可能です。

テストは添付のとおり、無事パスすることを確認しています。
![image](https://github.com/user-attachments/assets/f1cf430d-0271-40e9-be27-1a6c9ba6fb10)


## [feat:Create機能に対する結合テストを実装。](https://github.com/Ema-Sakai/Assignment-10/pull/14/commits/72951e340a30ffcea7164b10cc2c86aa4677c082) について
以下のような構成にしました。
- 正常系テスト
  - 新しい予約情報を作成できて予約情報がレスポンスされること
- 異常系テスト
  - バリデーションに引っかかる内容でリクエストするとBadRequestと入力規則が返ること
  - 空文字でリクエストするとBadRequestとエラーメッセージが返ること
</br>

## [feat:Read機能に対する結合テストを実装。](https://github.com/Ema-Sakai/Assignment-10/pull/14/commits/5c959efc0a5b24abd0e0137699480814eb929d32) について
以下のような構成にしました。
- 正常系テスト
  - 指定した予約番号の予約情報を取得できること
- 異常系テスト
  - 存在しない予約番号を指定した時にNotFoundとエラーメッセージが返ること
  - 不正な予約番号を指定した時にBadRequestとエラーメッセージが返ること
  - 空の予約番号を指定した時にMethodNotAllowedが返ること
</br>

## [feat:Update機能に対する結合テストを実装。](https://github.com/Ema-Sakai/Assignment-10/pull/14/commits/d87d5220570f8a69de4159b335d4a11b1f664df6) について
以下のような構成にしました。
- 正常系テスト
  - 指定した予約番号の予約情報を更新できること
- 異常系テスト
  - 未登録予約番号をリクエストした場合にNotFoundとエラーメッセージが返ること
  - 不正な内容をリクエストした場合にBadRequestとエラーメッセージが返ること*
  - 予約内容の変更を加えないままリクエストした場合にBadRequestが返ること
  - 空の予約番号を指定した時にMethodNotAllowedが返ること

*･･･IntelliJでテストを実行した際はパスしたが、GitHubにPRを作成したところここのテストがエラーとなった。
原因は、期待されるステータスコードは400（Bad Request）ですが、実際には404（Not Found）が返されていたようです。ターミナルから`./gradlew test`を実行することでようやく気づけました。
`./gradlew test`の実行方法にたどり着くまでに時間を要したため、これをきっかけにテスト結果をアーティファクトとして残し、ActionsタブからDLできるようにしました。
エラーの解消については、404が返ってくるというところから予約番号を`@DataSet`で準備しないといけないのか…！というところに気づき解消しました。
</br>

## [feat:Delete機能に対する結合テストを実装。](https://github.com/Ema-Sakai/Assignment-10/pull/14/commits/3927b944229d6549fec788acf1affb3c7adfa82e) について
以下のような構成にしました。
- 正常系テスト
  - 予約情報を削除できること
- 異常系テスト
  - 存在しない予約番号を指定した時にNotFoundとエラーメッセージが返ること
  - 削除済みの予約番号をリクエストした場合にNotFoundが返ること
  - 不正な予約番号を指定した時にBadRequestとエラーメッセージが返ること
  - 空の予約番号を指定した時にMethodNotAllowedが返ること
</br>

## `./gradlew test`の実行方法について（備忘録）
今回は以下のとおり`JAVA_HOME環境変数`を設定しないとテストを実行できなかった。
1. Windowsの検索バーで「環境変数」と入力し、「システム環境変数の編集」を選択。
2. 表示されたウィンドウの、下部にある「環境変数(N)...」ボタンをクリック。
3. 「システム環境変数」セクション（下半分）で「新規(W)...」ボタンをクリック。
4. 新しいシステム変数を作成。
    - 変数名：JAVA_HOME
    - 変数値：自分のJDK のルートディレクトリを設定（IntelliJの`File > Project Structure`を開き`SDKsのJDK home path`に記載がある）
5. 「OK」をクリックして新しい変数を保存。
6. 次に、既存の「Path」環境変数を編集。
    - 「システム環境変数」リストで「Path」を選択して「編集(I)...」をクリック。
    - 「新規(N)」をクリックし`%JAVA_HOME%\bin`を追加。

これを行ったらようやく `./gradlew test`を打ってテストを実行することが可能となった。
</br>

## 知れて良かった便利なこと4選
1. `@ValueSource`
    - 特定の値のセットをテストメソッドに渡すことができる。複数の数値や文字列を使って同じテストを繰り返し実行する場合に便利。（単一の引数を持つテストケースを複数回実行するってところが、`@CsvSource`との違い）
2. `@CsvSource`
    - 複数の引数をカンマ区切りで指定できるため、複数のパラメータを持つテストケースを作成できる。（複数の引数を持つテストケースを複数回実行するってところが、`@ValueSource`との違い）
3. [`andExpectAll`](https://spring.pleiades.io/spring-framework/docs/current/javadoc-api/org/springframework/test/web/servlet/ResultActions.html#andExpectAll(org.springframework.test.web.servlet.ResultMatcher...)) と`assertAll`
    - 複数の期待値を一度に指定し、すべての期待値がアサートされることを保証する。（つまり、複数の期待値を一度に指定でき、とある期待値が失敗しても他の期待値の検証が続行される。これによりどの期待値が成功し、どの期待値が失敗したかを一度に確認することができる。）
    - `andExpectAll`はHTTPレスポンス全体を対象にし、`assertAll`は任意のオブジェクトや値を対象にする。
4. `switch文`
    - `if文`のほうが好きかも～ってぼんやり思っていたが、複数の条件分岐を簡潔に記述できるため視覚的にも分かり易くめちゃくちゃ好きかも。

[1と2についてかみ砕いたサイト](https://qiita.com/unmelt/items/dc63a01935bfdd309202)